### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+
+# command to install dependencies
+# install: "pip install - requirements.txt"
+
+# command to run tests
+script: python -m unittest


### PR DESCRIPTION
The proposed `.travis.yml` executes all tests (using `unittest`) in Python versions 3.4 and 3.5.
